### PR TITLE
Kirby 3.6 Issues solved

### DIFF
--- a/index.php
+++ b/index.php
@@ -14,6 +14,12 @@ Kirby::plugin('sylvainjule/bouncer', [
             $user  = kirby()->user();
             if(!$user) return;
 
+            if (str_starts_with($path, "dialogs")
+                || str_starts_with($path, "dropdowns")
+                || str_starts_with($path, "search")) {
+                return;
+            }
+
             $currentRole = $user->role()->name();
 
             foreach(option('sylvainjule.bouncer.list') as $role => $options) {

--- a/lib/bouncer.php
+++ b/lib/bouncer.php
@@ -2,7 +2,7 @@
 
 class Bouncer {
 
-    private static function getChildren($allowed, Page $page) {
+    private static function getChildren($allowed, Kirby\Cms\Page $page) {
         if (!$page->hasChildren()) {
             return [];
         }

--- a/lib/bouncer.php
+++ b/lib/bouncer.php
@@ -2,6 +2,27 @@
 
 class Bouncer {
 
+    private static function getChildren($allowed, Page $page) {
+        if (!$page->hasChildren()) {
+            return [];
+        }
+
+        $allowed = [];
+        $pages = $page->childrenAndDrafts();
+        foreach($pages as $p) {
+            $allowed[] = [
+                'title' => $p->title()->value(),
+                'path'  => $p->panelUrl(true)
+            ];
+
+
+            $children = Bouncer::getChildren($allowed, $p);
+            $allowed = array_merge($allowed, $children);
+        }
+
+        return $allowed;
+    }
+
     public static function getAllowedPages($user, $fieldname, $extra = false) {
         $kirby   = kirby();
         $allowed = [];
@@ -15,6 +36,9 @@ class Bouncer {
                     'title' => $page->title()->value(),
                     'path'  => $page->panelUrl(true)
                 ];
+
+                $children = $extra ? Bouncer::getChildren($allowed, $page) : [];
+                $allowed = array_merge($allowed, $children);
             }
         }
 


### PR DESCRIPTION
The panel does a few calls where also the bouncer plugin tries to work. With the change the relevant paths are excluded. 
Other issue was that the children of the configured page were not allowed, which is now solved