### PR TITLE
Make login page allowed in extras

### DIFF
--- a/lib/bouncer.php
+++ b/lib/bouncer.php
@@ -27,6 +27,10 @@ class Bouncer {
                 'path'  => '/account'
             ];
             $allowed[] = [
+                'title' => 'Login',
+                'path'  => '/login'
+            ];
+            $allowed[] = [
                 'title' => 'Logout',
                 'path'  => '/logout'
             ];


### PR DESCRIPTION
Fix issue where user blueprint with the `home` option can not be redirected correctly.