### PR TITLE
Access to file panel pages

### DIFF
--- a/index.php
+++ b/index.php
@@ -2,6 +2,12 @@
 
 require_once __DIR__ . '/lib/bouncer.php';
 
+if (!function_exists('str_starts_with')) {
+    function str_starts_with($haystack, $needle) {
+        return (string)$needle !== '' && strncmp($haystack, $needle, strlen($needle)) === 0;
+    }
+}
+
 Kirby::plugin('sylvainjule/bouncer', [
     'options'  => [
         'list'       => []

--- a/lib/bouncer.php
+++ b/lib/bouncer.php
@@ -34,12 +34,32 @@ class Bouncer {
 
         return $allowed;
     }
+    
+    private static function getChildrenFiles(Kirby\Cms\Page $page) {
+        if (!($page->hasFiles())) { return []; }
+        
+        $allowed = [];
+        $files   = $page->files();
+        foreach($files as $f) {
+            $allowed[] = [
+                'title' => $f->title()->value(),
+                'path'  => $f->panel()->url(true)
+            ];
+        }
+
+        return $allowed;
+    }
 
     private static function getChildren(Kirby\Cms\Page $page) {
-        if (!($page->hasChildren() || $page->hasDrafts())) { return []; }
+        if (!($page->hasChildren() || $page->hasDrafts() || $page->hasFiles())) { return []; }
 
         $allowed = [];
         $pages   = $page->childrenAndDrafts();
+        
+        if($page->hasFiles()){
+            $files = static::getChildrenFiles($page);
+            $allowed  = array_merge($allowed, $files);
+        }
 
         foreach($pages as $p) {
             $allowed[] = [


### PR DESCRIPTION
This change allows access to file panel pages of an allowed page if there are any.

`str_starts_with()` causes error if you don't have php8, so added a conditional statement if the function is not found. [reference]( https://www.php.net/manual/en/function.str-starts-with.php)

Seems to work with kirby 3.7.0. and php7.4 (my working environment)
