### PR TITLE
Added 'extra-allowed' array to config

### DIFF
--- a/index.php
+++ b/index.php
@@ -36,7 +36,8 @@ Kirby::plugin('sylvainjule/bouncer', [
                     $currentPath  = '/'. $path;
 
                     if(!in_array($currentPath, $allowedPaths)) {
-                        Panel::go($allowedPaths[0]);
+                        $fallback = option('sylvainjule.bouncer.fallback', $allowedPaths[0]);
+                        Panel::go($fallback);
                     }
                 }
             }

--- a/lib/bouncer.php
+++ b/lib/bouncer.php
@@ -38,14 +38,15 @@ class Bouncer {
                 'title' => 'Reset password',
                 'path'  => '/reset-password'
             ];
+            $allowed = array_merge($allowed, $kirby->option('sylvainjule.bouncer.extra-allowed', []));
         }
 
         return $allowed;
     }
-    
+
     private static function getChildrenFiles(Kirby\Cms\Page $page) {
         if (!($page->hasFiles())) { return []; }
-        
+
         $allowed = [];
         $files   = $page->files();
         foreach($files as $f) {
@@ -63,7 +64,7 @@ class Bouncer {
 
         $allowed = [];
         $pages   = $page->childrenAndDrafts();
-        
+
         if($page->hasFiles()){
             $files = static::getChildrenFiles($page);
             $allowed  = array_merge($allowed, $files);


### PR DESCRIPTION
I added an extra configuration option to the plugin. With that, the list of allowed-pages can be extended in the kirby configuration to allow the creation of areas in other plugins.

An example config now looks like:

```
'sylvainjule.bouncer' => [
        'list'=> [
            '<role>' => [
                'fieldname' => 'canaccess'
            ],
        ],
        'extra-allowed' => [
            [
                'title' => 'Area Title',
                'path'  => '/area-path'
            ]
        ]
    ]
```